### PR TITLE
[CIVIS-6117] change references of civis-authority back to authority

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 Authority does its best to use [semantic versioning](http://semver.org).
 
+## 4.0.1
+
+- change references to civis-authority back to authority
+
 ## 4.0.0
 
 - Drops support for Ruby 1.X

--- a/authority.gemspec
+++ b/authority.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.files -= spec.files.select { |f| f.match(%r{^(bin|spec|features|gemfiles)/}) }
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  spec.name          = 'civis-authority'
+  spec.name          = 'authority'
   spec.require_paths = ['lib']
   spec.version       = Authority::VERSION
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,6 @@ services:
       - "3009:3000"
     volumes:
       - .:/src
+      - ~/.gem:/root/.gem
 
     command: tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,5 @@ services:
       - "3009:3000"
     volumes:
       - .:/src
-      - ~/.gem:/root/.gem
 
     command: tail -f /dev/null

--- a/lib/authority/version.rb
+++ b/lib/authority/version.rb
@@ -1,3 +1,3 @@
 module Authority
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
## Description
change references of civis-authority back to authority


## Context, Consequences, & Considerations
Please step through the following list, pausing at each item to consider your change in relation to the item's context.
Check the box to mark that it applies, and enter your relevant notes under the item.

- [ ] Security: This has security implications. This includes (but not limited to) adding users, modifying user/app permissions, network rules/policies, changing a system interconnection, or changing an authorization strategy.
  - [x] This PR does not require security review. These changes are part of a project plan that has already undergone security review. The link is provided below.
  - [ ] This PR requires security review. Add the `security` label to this PR then request a review from the [Security Code Reviewers Team](https://github.com/orgs/civisanalytics/teams/security-code-reviewers).

>
- [x] Execution: This change requires commands to be run outside of the normal merge.

locally 
produce authority-4.0.1.gem file
> gem build authority.gemspec 
push the gem
> gem push authority-4.0.1.gem

- [ ] Execution: Applying this change will modify production data. This includes (but not limited to) database migrations, rake tasks that modify data, or other processes.

>

- [ ] Impact: This change may cause service interruptions.

>

- [x] Testing: How did you test this change (unit tests, acceptance tests, etc.)? Did you do any manual testing?

> unit tests
> manual tests via installing into console repo using git reference

- [x] Testing: How will you confirm this change once it's merged?

> manual tests via installing into console repo using git reference

- [ ] Documentation: Documentation to reflect this change has been added to Confluence or Zendesk.

>

- [x] **All items of the checklist have been considered and this PR description is complete.**
